### PR TITLE
Deduplicate EVM addresses case-insensitively

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,18 @@
           .split(/[\s,;\n\r]+/)
           .map((s) => s.trim())
           .filter(Boolean);
-        const uniq = Array.from(new Set(parts));
-        return uniq.filter((a) => isEvm(a) || isSol(a));
+        const seen = new Set();
+        const out = [];
+        for (const addr of parts) {
+          let key = null;
+          if (isEvm(addr)) key = addr.toLowerCase();
+          else if (isSol(addr)) key = addr;
+          else continue;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          out.push(addr);
+        }
+        return out;
       };
 
       // Pretty color per zone label

--- a/src/TimezoneMapUI.jsx
+++ b/src/TimezoneMapUI.jsx
@@ -18,8 +18,18 @@ export const parseAddresses = (text) => {
     .split(/[\s,;\n\r]+/)
     .map((s) => s.trim())
     .filter(Boolean);
-  const uniq = Array.from(new Set(parts));
-  return uniq.filter((a) => isEvm(a) || isSol(a));
+  const seen = new Set();
+  const out = [];
+  for (const addr of parts) {
+    let key = null;
+    if (isEvm(addr)) key = addr.toLowerCase();
+    else if (isSol(addr)) key = addr;
+    else continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(addr);
+  }
+  return out;
 };
 
 const pastelFromLabel = (label) => {


### PR DESCRIPTION
## Summary
- ensure `parseAddresses` treats EVM addresses case-insensitively and removes duplicates
- mirror parser fix in demo HTML

## Testing
- `node -e "const isEvm=(s)=>/^(0x)[0-9a-fA-F]{40}$/.test(s);const isSol=(s)=>/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(s);const parseAddresses=(text)=>{const parts=String(text||'').split(/[\s,;\n\r]+/).map(s=>s.trim()).filter(Boolean);const seen=new Set();const out=[];for(const addr of parts){let key=null;if(isEvm(addr)) key=addr.toLowerCase(); else if(isSol(addr)) key=addr; else continue; if(seen.has(key)) continue; seen.add(key); out.push(addr);}return out;};console.log(parseAddresses('0xabc0000000000000000000000000000000000000 0xABC0000000000000000000000000000000000000 1BoatSLRHtKNngkdXEeobR76b53LETtpyT 1BoatSLRHtKNngkdXEeobR76b53LETtpyT'))"`

------
https://chatgpt.com/codex/tasks/task_e_68a0dfadc360832d9b4513b533415d17